### PR TITLE
SC-894 - Pod Commands

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,6 +36,7 @@ autolabeler:
   - label: "enhancement"
     branch:
       - "/enhancement\/.+/"
+      - "/enhance\/.+/"
   - label: "fix"
     branch:
       - "/fix\/.+/"

--- a/.github/workflows/cocoapods-release.yml
+++ b/.github/workflows/cocoapods-release.yml
@@ -24,7 +24,7 @@ jobs:
       # Check the podspec file for any issues
       - name: Lint Podspec
         run: |
-          pod spec lint
+          pod spec lint ${{ env.PODSPEC_PATH }} --allow-warnings --verbose
 
       # Update the semantic version number in the .TempoSDK.podspec file
       - name: Update Version
@@ -66,5 +66,7 @@ jobs:
 
       # Using the podspec, push the latest version of the pod to CocoaPod
       - name: Push Pod
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          pod trunk push --allow-warnings --verbose
+          pod trunk push ${{ env.PODSPEC_PATH }} --allow-warnings --verbose

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ TempoSDK is a library containing the code that handles the display of ad content
 - [Source Control](#source-control)
     * [Branching](#branching)
     * [Pull Requests](#pull-requests)
+- [CI/CD](#cicd)
+    * [Release Drafter](#release-drafter)
+        + [On Pull Request Open, Re-Opened or Synchronize](#on-pull-request-open-re-opened-or-synchronize)
+        + [On Push to Master](#on-push-to-master)
+    * [Publishing](#publishing)
 
 ## Example App
 
@@ -73,3 +78,34 @@ The last part of the commit message is a brief description of the changes.
 [About Pull Requests | GitHub](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
 
 Before merging our branch into development or master, we **must** create a pull request in the repository.
+
+## CI/CD
+
+### Release Drafter
+
+The release-drafter.yml workflow is the mechanism by which a release number tag is generated for pod releases of the tempo-ios-sdk repo. This tag is then used when pushing pods to the CocoaPods Trunk.
+
+This is all accomplished by the release-drafter workflow running in the following scenarios:
+
+#### On Pull Request Open, Re-Opened or Synchronize
+
+Whenever a pull request is created, the release drafter workflow runs it's [autolabeler](https://github.com/release-drafter/release-drafter#autolabeler) functionality which adds [labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) to the pull request based on the branch name.
+
+Versions numbers and their associated branch name patterns and labels are as follows:
+
+| [Version Number Increment](https://semver.org/) | Branch Name                                                                         | Generated Label                            |
+|-------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------|
+| Major (1.X.X)                                   | N/A                                                                                 | breaking                                   |
+| Minor (X.1.X)                                   | "feature/..."<br>"feat/..."<br>"enhancement/..."<br>"enhance/..."<br>"refactor/..." | feature<br><br>enhancement<br><br>refactor |
+| Patch (X.X.1)                                   | "fix/..."<br>"bugfix/..."<br>"chore/..."                                            | fix<br><br>chore                           |
+
+#### On Push to Master
+
+When a pull request is closed and pushed to master, release drafter will either create a new release or append the currently opened draft release with the following:
+* A bump to the required version
+* Details around the closed pull request under specific headings
+* Contributor details
+
+### Publishing
+
+Once you are satisfied with a release, publish it to then trigger the push to CocoaPods.

--- a/TempoSDK.podspec
+++ b/TempoSDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/Tempo-Platform/tempo-ios-sdk'
   spec.readme           = 'https://github.com/Tempo-Platform/tempo-ios-sdk/blob/main/README.md'
-  spec.source           = { :git => 'https://github.com/Tempo-Platform/tempo-ios-sdk.git', :tag => s.version.to_s }
+  spec.source           = { :git => 'https://github.com/Tempo-Platform/tempo-ios-sdk.git', :tag => spec.version.to_s }
   spec.summary          = 'Tempo SDK to show payable ads'
 
   spec.ios.deployment_target = '11.0'


### PR DESCRIPTION
* Fixed an issue with the `podspec` around the `s` -> `spec` alias
* Added `COCOAPODS_TRUNK_TOKEN` access in the `push-pod` job
* Added details to the README around CI/CD and release-drafter
* Added an additional branch regex to the release-drafter config