### PR TITLE
SC-894 - Output, Push & Permissions

### DIFF
--- a/.github/workflows/cocoapods-release.yml
+++ b/.github/workflows/cocoapods-release.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Permissions Monitor
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - name: Checkout Repository
         uses: actions/checkout@v3
 
@@ -45,10 +50,13 @@ jobs:
     environment: production
 
     steps:
+      - name: Permissions Monitor
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - name: Checkout Repository
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       # Using the podspec, push the latest version of the pod to CocoaPod
       - name: Push Pod

--- a/.github/workflows/cocoapods-release.yml
+++ b/.github/workflows/cocoapods-release.yml
@@ -18,28 +18,26 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-        with:
-          ref: main
-
-      # Check the podspec file for any issues
-      - name: Lint Podspec
-        run: |
-          pod spec lint ${{ env.PODSPEC_PATH }} --allow-warnings --verbose
 
       # Update the semantic version number in the .TempoSDK.podspec file
       - name: Update Version
         shell: pwsh
         run: |
           $version = "'${{ github.event.release.tag_name }}'"
+          Write-Output "Attempting to update podspec version to $version"
+          
           $podspec = Get-Content "$env:PODSPEC_PATH"
           $podspec = $podspec -replace '^(.*spec.version.*)(''.*'')$', "`$1$version"
+          
+          Write-Output "Adjusted podspec:`n$podspec"
+          
           $podspec | Set-Content -Path "$env:PODSPEC_PATH" -Force
 
       # Push the updated podspec file
       - name: Push Changes
         uses: ad-m/github-push-action@master
         with:
-          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   push-pod:
     needs: validate-update-podspec
@@ -57,4 +55,4 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          pod trunk push ${{ env.PODSPEC_PATH }} --skip-import-validation --skip-tests --allow-warnings --verbose
+          pod trunk push ${{ env.PODSPEC_PATH }} --allow-warnings --verbose

--- a/.github/workflows/permissions-advisor.yml
+++ b/.github/workflows/permissions-advisor.yml
@@ -1,0 +1,27 @@
+name: Permissions Advisor
+
+permissions:
+  actions: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'The name of the workflow file to analyze'
+        required: true
+        type: string
+      count:
+        description: 'How many last runs to analyze'
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  advisor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/advisor@v1
+        with:
+          name: ${{ inputs.name }}
+          count: ${{ inputs.count }}


### PR DESCRIPTION
* Removed `Lint Podspec` step
* Added output to `Update Version` step
* Removed branch references in `validate-update-podspec` job
* Added `Permissions Monitor` step to all jobs in `cocoapods-release` workflow
* Added `permissions-advisor` workflow