### PR TITLE
SC-894 - Autolabeler Branches

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,22 +31,22 @@ version-resolver:
 autolabeler:
   - label: "feature"
     branch:
-      - "/feature\/.+/"
-      - "/feat\/.+/"
+      - "/feature[\/|-].+/"
+      - "/feat[\/|-].+/"
   - label: "enhancement"
     branch:
-      - "/enhancement\/.+/"
-      - "/enhance\/.+/"
+      - "/enhancement[\/|-].+/"
+      - "/enhance[\/|-].+/"
   - label: "fix"
     branch:
-      - "/fix\/.+/"
-      - "/bugfix\/.+/"
+      - "/fix[\/|-].+/"
+      - "/bugfix[\/|-].+/"
   - label: "refactor"
     branch:
-      - "/refactor\/.+/"
+      - "/refactor[\/|-].+/"
   - label: "chore"
     branch:
-      - "/chore\/.+/"
+      - "/chore[\/|-].+/"
 template: |
   ## What's Changed
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Whenever a pull request is created, the release drafter workflow runs it's [auto
 
 Versions numbers and their associated branch name patterns and labels are as follows:
 
-| [Version Number Increment](https://semver.org/) | Branch Name                                                                         | Generated Label                            |
-|-------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------|
-| Major (1.X.X)                                   | N/A                                                                                 | breaking                                   |
-| Minor (X.1.X)                                   | "feature/..."<br>"feat/..."<br>"enhancement/..."<br>"enhance/..."<br>"refactor/..." | feature<br><br>enhancement<br><br>refactor |
-| Patch (X.X.1)                                   | "fix/..."<br>"bugfix/..."<br>"chore/..."                                            | fix<br><br>chore                           |
+| [Version Number Increment](https://semver.org/) | Branch Name                                                                                                                                                                | Generated Label                                            |
+|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| Major (1.X.X)                                   | N/A                                                                                                                                                                        | breaking                                                   |
+| Minor (X.1.X)                                   | "feature/..."<br>"feature-..."<br>"feat/..."<br>"feat-..."<br>"enhancement/..."<br>"enhancement-..."<br>"enhance/..."<br>"enhance-..."<br>"refactor/..."<br>"refactor-..." | feature<br><br><br><br>enhancement<br><br><br><br>refactor |
+| Patch (X.X.1)                                   | "fix/..."<br>"fix-..."<br>"bugfix/..."<br>"bugfix-..."<br>"chore/..."<br>"chore-..."                                                                                       | fix<br><br><br><br>chore                                   |
 
 #### On Push to Master
 


### PR DESCRIPTION
* Added to branch regex in `release-drafter` config autolabeler to include dashes (`-`)
* Updated README to reflect changes